### PR TITLE
Use Ginkgo V2

### DIFF
--- a/ci/tasks/run-performance-tests/task.sh
+++ b/ci/tasks/run-performance-tests/task.sh
@@ -73,10 +73,10 @@ results_folder: "$results_path"
 EOF
   if [ -z "${TEST_SUITE_FOLDER:-}" ]; then
     echo -e "\nRunning all tests..."
-    ginkgo ./...
+    go run github.com/onsi/ginkgo/v2/ginkgo ./...
   else
     echo -e "\nRunning tests in ${TEST_SUITE_FOLDER}..."
-    ginkgo -r "$TEST_SUITE_FOLDER"
+    go run github.com/onsi/ginkgo/v2/ginkgo -r "$TEST_SUITE_FOLDER"
   fi
 popd >/dev/null
 


### PR DESCRIPTION
The [ginkgo guide](https://onsi.github.io/ginkgo/#recommended-continuous-integration-configuration) recommends using the format `go run github.com/onsi/ginkgo/v2/ginkgo` to run tests and aligning the version of the CLI and then version in `go.mod`. This PR updates the `task.sh` to run the tests this way.

**This change should be undone when [this PR](https://github.com/cloudfoundry/cf-deployment-concourse-tasks/pull/127), bumping the ginkgo cli to V2 on the Docker image, has been merged.**