### PR TITLE
Fix the problem of incorrect display of generated charts

### DIFF
--- a/ci/tasks/generate-charts/generate_charts.py
+++ b/ci/tasks/generate-charts/generate_charts.py
@@ -90,7 +90,7 @@ def generate_chart(prefix, chart_destination: str, file_paths: List[str], simpli
         width_per_test = 0.6
 
     width = max((width_per_test * len(test_executions)), 10)
-    fig.set_size_inches(width, 1.5 * len(test_results))
+    fig.set_size_inches(width, 3 * len(test_results))
 
     i = 0
     label_locations = np.arange(len(test_executions))


### PR DESCRIPTION
cf-performance-test results' charts of

```
results/rails/postgres/charts/service-keys-test-results/v1/service-keys-detailed-chart-with-most-recent-runs.png
results/rails/postgres/charts/service-keys-test-results/v1/service-keys-simple-chart-with-most-recent-runs.png
results/rails/postgres/charts/users-test-results/v1/users-detailed-chart-with-most-recent-runs.png
results/rails/postgres/charts/users-test-results/v1/users-simple-chart-with-most-recent-runs.png
results/rails/mysql/charts/service-keys-test-results/v1/service-keys-detailed-chart-with-most-recent-runs.png
results/rails/mysql/charts/service-keys-test-results/v1/service-keys-simple-chart-with-most-recent-runs.png
results/rails/mysql/charts/users-test-results/v1/users-detailed-chart-with-most-recent-runs.png
results/rails/mysql/charts/users-test-results/v1/users-simple-chart-with-most-recent-runs.png
```
From a long time ago the results were not displayed correctly, generated images like:
<img width="1072" alt="Screenshot 2024-03-07 at 13 02 48" src="https://github.com/cloudfoundry/cf-performance-tests-pipeline/assets/64415962/584da0bd-c5e7-4e9d-91fd-ef1aa8f88b34">

With the fix, all charts will show the test results without problem, for example: 
<img width="1060" alt="Screenshot 2024-03-14 at 14 39 11" src="https://github.com/cloudfoundry/cf-performance-tests-pipeline/assets/64415962/5066313a-e5a4-4b06-a297-4cc16127bb29">

