### PR TITLE
Use bigger vm for errand

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -136,12 +136,6 @@ resources:
     source:
       uri: https://github.com/cloudfoundry/cf-deployment.git
       tag_filter: v*
-  - name: cf-performance-tests
-    type: git
-    icon: github
-    source:
-      uri: https://github.com/cloudfoundry/cf-performance-tests.git
-      branch: main
   - name: slack-notification
     type: slack-alert
     source:
@@ -246,7 +240,6 @@ jobs:
           passed: [deploy-director]
         - get: base-infra
         - get: concourse-tasks
-        - get: cf-performance-tests
       - load_var: base-infra
         file: base-infra/metadata
         format: json
@@ -346,7 +339,6 @@ jobs:
           passed: [run-perf-tests-postgres]
         - get: base-infra
         - get: concourse-tasks
-        - get: cf-performance-tests
       - load_var: base-infra
         file: base-infra/metadata
         format: json

--- a/operations/performance-tests-errand.yml
+++ b/operations/performance-tests-errand.yml
@@ -16,12 +16,13 @@
               username: admin
               password: ((cf_admin_password))
           results_folder: ((results_folder))
+          samples: 10
         release: cf-performance-tests
     lifecycle: errand
     networks:
       - name: default
     stemcell: default
-    vm_type: small
+    vm_type: m5a.large
 
 - type: replace
   path: /releases/-


### PR DESCRIPTION
To improve test stability we switch from a burstable VM instances to a stable and bigger one. Additionally increase the sample size from 5 to 10.

Also removing concourse resource `cf-performance-tests`. It is no longer needed since we consume the errand bosh release directly.