### PR TITLE
Fix generate-coverage-table job

### DIFF
--- a/ci/results-pipeline.yml
+++ b/ci/results-pipeline.yml
@@ -8,7 +8,7 @@ resources:
     password: ((ari-wg-gitbot-token))
     branch: ((results-branch))
     paths: [ci/results-pipeline.yml, ci/tasks/generate-charts/*, ci/tasks/generate-coverage-table/*, variables/common.yml]
-    ignore_paths: [results/**/*.json, results/coverage.md]
+
 - name: results
   type: git
   icon: github
@@ -87,6 +87,7 @@ jobs:
     params:
       repository: results-with-all-charts
       rebase: true
+
 - name: generate-coverage-table
   serial: true
   plan:
@@ -96,8 +97,6 @@ jobs:
   - get: results
     trigger: true
   - task: generate-coverage-table
-    input_mapping:
-      cf-performance-tests-pipeline: results
     file: cf-performance-tests-pipeline/ci/tasks/generate-coverage-table/task.yml
     params:
       COVERAGE_TABLE_FILE: results/coverage.md
@@ -106,5 +105,5 @@ jobs:
       GIT_COMMIT_MESSAGE: Update test coverage table
   - put: cf-performance-tests-pipeline-push
     params:
-      repository: cf-performance-tests-pipeline
+      repository: results
       rebase: true

--- a/ci/tasks/generate-coverage-table/task.sh
+++ b/ci/tasks/generate-coverage-table/task.sh
@@ -1,11 +1,11 @@
 #!/bin/bash
 
-set -euo pipefail
+set -xeuo pipefail
 
 task_root="$(pwd)"
 cf_perf_tests_pipeline_repo="${task_root}/cf-performance-tests-pipeline"
-results_dir="${cf_perf_tests_pipeline_repo}/results"
-coverage_file="${cf_perf_tests_pipeline_repo}/${COVERAGE_TABLE_FILE}"
+results_dir="${task_root}/results"
+coverage_file="${results_dir}/${COVERAGE_TABLE_FILE}"
 
 script_dir="$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 pip install -r "${script_dir}/requirements.txt"
@@ -14,14 +14,14 @@ python "${cf_perf_tests_pipeline_repo}/ci/tasks/generate-coverage-table/generate
   --results-root-dir "$results_dir" \
   --output-file "$coverage_file"
 
-pushd "${cf-performance-tests-pipeline}" > /dev/null
-  if [[ $(git diff --exit-code "${coverage_file}") ]]; then
-    echo -e "\nNo changes in coverage.md file: ${coverage_file}"
+pushd "${results_dir}" > /dev/null
+  if [[ $(git diff --exit-code "${COVERAGE_TABLE_FILE}") ]]; then
+    echo -e "\nNo changes in coverage.md file: ${COVERAGE_TABLE_FILE}"
   else
     echo -e "\nCommitting coverage table..."
     git -C "$cf_perf_tests_pipeline_repo" config user.name "$GIT_COMMIT_USERNAME"
     git -C "$cf_perf_tests_pipeline_repo" config user.email "$GIT_COMMIT_EMAIL"
-    git -C "$cf_perf_tests_pipeline_repo" add "$coverage_file"
+    git -C "$cf_perf_tests_pipeline_repo" add "${COVERAGE_TABLE_FILE}"
     git -C "$cf_perf_tests_pipeline_repo" commit -m "$GIT_COMMIT_MESSAGE"
   fi
 popd > /dev/null

--- a/ci/tasks/generate-coverage-table/task.yml
+++ b/ci/tasks/generate-coverage-table/task.yml
@@ -6,10 +6,10 @@ image_resource:
     repository: python
 
 inputs:
-- name: cf-performance-tests-pipeline
+- name: results
 
 outputs:
-- name: cf-performance-tests-pipeline
+- name: results
 
 run:
   path: cf-performance-tests-pipeline/ci/tasks/generate-coverage-table/task.sh


### PR DESCRIPTION
* keep "cf-performance-tests-pipeline" and "results" resources separate
* "cf-performance-tests-pipeline" is triggered when the pipeline or task definitions change
* "results" is used to run the Python script which changes the "coverage.md" file